### PR TITLE
Add a --prepend flag to the preview action

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ alias emoj="emoji-fzf preview | fzf --preview 'emoji-fzf get --name {1}' | cut -
 emoj | xclip -selection c
 ```
 
+## Alternative setup
+
+If you prefer not to use fzf's preview feature and have the emojis appear
+before their aliases you can use the following alias instead:
+
+```bash
+alias emoj="emoji-fzf preview --prepend | fzf | awk '{ print \$1 }'"
+```
+
 ## Devlopment/testing
 
 This uses a Dockerfile to keep the test build environment relatively clean and

--- a/emoji_fzf/emoji_fzf.py
+++ b/emoji_fzf/emoji_fzf.py
@@ -20,9 +20,19 @@ def cli():
 
 
 @cli.command()
-def preview():
+@click.option(
+    "--prepend",
+    "prepend_emoji",
+    help="Whether to prefix the preview with the emoji",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+def preview(prepend_emoji=False):
     """Return an fzf-friendly search list for emoji"""
     for key, val in EMOJIS.items():
+        if prepend_emoji:
+            click.secho(u"{} ".format(val["emoji"]), nl=False)
         click.secho(key, bold=True, nl=False)
         click.echo(u" {}".format(u" ".join(val["aliases"])))
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,9 @@ commands =
     emoji-fzf --help
     emoji-fzf --version
     bash -c "emoji-fzf preview > /dev/null"
+    bash -c "emoji-fzf preview --prepend > /dev/null"
+    bash -c "emoji-fzf preview | grep -q '^thumbs_up'"
+    bash -c "emoji-fzf preview --prepend | grep -q '^👍 thumbs_up'"
     emoji-fzf get --name dragon
     echo "dragon" | emoji-fzf get
 


### PR DESCRIPTION
This PR adds a new flag:

- `--prepend`: when set it output the emoji before the aliases

ie:

```bash
$ emoji-fzf preview | grep -m 1 'thumbs_up'
thumbs_up good accept like yes hand thumbsup +1 awesome agree cool
$ emoji-fzf preview --prepend | grep -m 1 'thumbs_up'       
👍 thumbs_up good accept like yes hand thumbsup +1 awesome agree cool
```