### PR TITLE
✨ Custom aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,13 @@ aliases and not replace them.
 ```json
 [
   {
-    "emoji": "👍",
-    "aliases": [
+    "👍": [
       "my-custom-alias",
       "good-boy"
     ]
   },
   {
-    "emoji": "💯",
-    "aliases": [
+    "💯": [
       "epic-victory-royale"
     ]
   }
@@ -78,7 +76,7 @@ aliases and not replace them.
 2. Now you can call `emoji-fzf` like so:
 
 ```bash
-emoji-fzf preview --custom-aliases /path/to/your-custom-aliases.json
+emoji-fzf --custom-aliases /path/to/your-custom-aliases.json preview
 ```
 
 ## Development/testing

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ aliases and not replace them.
     "emoji": "💯",
     "aliases": [
       "epic-victory-royale"
+    ]
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,40 @@ before their aliases you can use the following alias instead:
 alias emoj="emoji-fzf preview --prepend | fzf | awk '{ print \$1 }'"
 ```
 
+## Custom aliases
+
+emoji-fzf uses a pre-defined set of aliases for every emoji. If you want to
+define your own, ie add custom aliases for some emojis you can do this via the
+`--custom-aliases` flag.
+
+Please note that these aliases will be appended to the list of pre-defined
+aliases and not replace them.
+
+1. First you need to create a JSON file with the following structure:
+
+```json
+[
+  {
+    "emoji": "👍",
+    "aliases": [
+      "my-custom-alias",
+      "good-boy"
+    ]
+  },
+  {
+    "emoji": "💯",
+    "aliases": [
+      "epic-victory-royale"
+  }
+]
+```
+
+2. Now you can call `emoji-fzf` like so:
+
+```bash
+emoji-fzf preview --custom-aliases /path/to/your-custom-aliases.json
+```
+
 ## Development/testing
 
 This uses a Dockerfile to keep the test build environment relatively clean and

--- a/emoji_fzf/emoji_fzf.py
+++ b/emoji_fzf/emoji_fzf.py
@@ -31,14 +31,14 @@ def cli(ctx, custom_aliases_file=None):
     emojis_custom = EMOJIS
     if custom_aliases_file:
         try:
-            custom_aliases = {
-                x.get("emoji"): x.get("aliases") for x in json.load(custom_aliases_file)
-            }
+            custom_aliases = json.load(custom_aliases_file)
         except AttributeError:
             print("The custom alias file provided is invalid", file=sys.stderr)
             sys.exit(2)
 
-        for emoji, cust_aliases in custom_aliases.items():
+        for item in custom_aliases:
+            emoji = list(item.keys())[0]
+            cust_aliases = item.get(emoji, [])
             for key, val in emojis_custom.items():
                 if val.get("emoji") == emoji:
                     emojis_custom[key]["aliases"] = set(
@@ -62,11 +62,11 @@ def cli(ctx, custom_aliases_file=None):
 @click.pass_context
 def preview(ctx, prepend_emoji=False):
     """Return an fzf-friendly search list for emoji"""
-    for key, val in ctx.obj["emojis"].items():
+    for name, val in ctx.obj["emojis"].items():
         emoji = val.get("emoji", "?")
         if prepend_emoji:
             click.secho(u"{} ".format(emoji), nl=False)
-        click.secho(key, bold=True, nl=False)
+        click.secho(name, bold=True, nl=False)
         click.echo(u" {}".format(u" ".join(val.get("aliases", set()))))
 
 

--- a/test-custom-aliases.json
+++ b/test-custom-aliases.json
@@ -1,15 +1,13 @@
 [
   {
-    "emoji": "🐉",
-    "aliases": [
+    "🐉": [
       "epic-dragon",
       "test",
       "random-custom-test-alias"
     ]
   },
   {
-    "emoji": "💯",
-    "aliases": [
+    "💯": [
       "test",
       "random-custom-test-alias"
     ]

--- a/test-custom-aliases.json
+++ b/test-custom-aliases.json
@@ -1,0 +1,17 @@
+[
+  {
+    "emoji": "🐉",
+    "aliases": [
+      "epic-dragon",
+      "test",
+      "random-custom-test-alias"
+    ]
+  },
+  {
+    "emoji": "💯",
+    "aliases": [
+      "test",
+      "random-custom-test-alias"
+    ]
+  }
+]

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ commands =
     bash -c "emoji-fzf preview --prepend > /dev/null"
     bash -c "emoji-fzf preview | grep -q '^thumbs_up'"
     bash -c "emoji-fzf preview --prepend | grep -q '^👍 thumbs_up'"
+    bash -c "emoji-fzf preview --custom-aliases test-custom-aliases.json | grep -q 'random-custom-test-alias'"
     emoji-fzf get --name dragon
     echo "dragon" | emoji-fzf get
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     bash -c "emoji-fzf preview --prepend > /dev/null"
     bash -c "emoji-fzf preview | grep -q '^thumbs_up'"
     bash -c "emoji-fzf preview --prepend | grep -q '^👍 thumbs_up'"
-    bash -c "emoji-fzf preview --custom-aliases test-custom-aliases.json | grep -q 'random-custom-test-alias'"
+    bash -c "emoji-fzf --custom-aliases test-custom-aliases.json preview | grep -q 'random-custom-test-alias'"
     emoji-fzf get --name dragon
     echo "dragon" | emoji-fzf get
 


### PR DESCRIPTION
So I implemented yet another flag for `preview`:

- `-c | --custom-aliases`: This accepts a file that holds custom user-defined aliases for the emojis provided by emoji-fzf

There's an [example as well](https://github.com/noahp/emoji-fzf/pull/12/files#diff-379409907184e712e587cd229e1007be). Should be pretty much self-explanatory.