### PR TITLE
✨ Optionally skip multichar emojis

### DIFF
--- a/emoji_fzf/emoji_fzf.py
+++ b/emoji_fzf/emoji_fzf.py
@@ -53,10 +53,20 @@ def cli(custom_aliases_file=None):
     default=False,
     show_default=True,
 )
-def preview(prepend_emoji=False):
+@click.option(
+    "--skip-multichar",
+    "skip_multichar",
+    help="Whether to skip multicharacter emojis",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+def preview(prepend_emoji=False, skip_multichar=False):
     """Return an fzf-friendly search list for emoji"""
     for name, val in EMOJIS.items():
         emoji = val.get("emoji", "?")
+        if skip_multichar and len(emoji) > 1:
+            continue
         if prepend_emoji:
             click.secho(u"{} ".format(emoji), nl=False)
         click.secho(name, bold=True, nl=False)

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ commands =
     bash -c "emoji-fzf preview | grep -q '^thumbs_up'"
     bash -c "emoji-fzf preview --prepend | grep -q '^👍 thumbs_up'"
     bash -c "emoji-fzf --custom-aliases test-custom-aliases.json preview | grep -q 'random-custom-test-alias'"
+    # --skip-multichar should return less lines
+    bash -c 'test "$(emoji-fzf preview --skip-multichar | wc -l)" -lt "$(emoji-fzf preview | wc -l)"'
     emoji-fzf get --name dragon
     echo "dragon" | emoji-fzf get
 


### PR DESCRIPTION
Since most terminals do not correctly display multicharacter emojis I'm proposing a flag to the preview action so that these do not get displayed.

TL;DR This allows to avoid the following (Konsole):

![image](https://user-images.githubusercontent.com/37886/109632412-4d9d9700-7b47-11eb-9fe0-91235dab8167.png)
