### PR TITLE
🧱 get multiple emojis in one invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You could add a shell alias like the following to your shell init script:
 export PATH=$PATH:~/.local/bin
 
 # add me to your ~/.bashrc or ~/.zshrc or whatnot
-alias emoj="emoji-fzf preview | fzf --preview 'emoji-fzf get --name {1}' | cut -d \" \" -f 1 | emoji-fzf get"
+alias emoj="emoji-fzf preview | fzf -m --preview "emoji-fzf get --name {1}" | cut -d " " -f 1 | emoji-fzf get"
 # to copy to xclip system keyboard (on mac use pbcopy) after selecting
 emoj | xclip -selection c
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -50,8 +50,15 @@ commands =
     bash -c "emoji-fzf --custom-aliases test-custom-aliases.json preview | grep -q 'random-custom-test-alias'"
     # --skip-multichar should return less lines
     bash -c 'test "$(emoji-fzf preview --skip-multichar | wc -l)" -lt "$(emoji-fzf preview | wc -l)"'
+    emoji-fzf get
+    emoji-fzf get blahblahgargbagenogood
+    emoji-fzf get dragon
+    emoji-fzf get dragon bus
     emoji-fzf get --name dragon
+    emoji-fzf get --name dragon bus
     echo "dragon" | emoji-fzf get
+    echo "dragon bus" | emoji-fzf get shower
+
 
 # verify the commit has an emoji :D
 [testenv:check-commit]


### PR DESCRIPTION
Update the `get` command to support taking emoji strings from:

- stdin
- `--name` command
- multiple positional args

Fixes #15
